### PR TITLE
Include tox.ini in the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
 include README.md
+include tox.ini
 recursive-include tests *.html *.json *.py


### PR DESCRIPTION
The sdist should contain all files necessary to test the package.