### PR TITLE
Strip leading/trailing whitespace from content before processing

### DIFF
--- a/html2docx.py
+++ b/html2docx.py
@@ -147,7 +147,7 @@ def html2docx(content: str, title: str) -> BytesIO:
     io.BytesIO() object.
     """
     parser = HTML2Docx(title)
-    parser.feed(content)
+    parser.feed(content.strip())
 
     buf = BytesIO()
     parser.doc.save(buf)


### PR DESCRIPTION
Sanitize input before processing to avoid stray whitespace
making it into the resulting document