### PR TITLE
Remove 'dist: xenial' from Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: xenial
 language: python
 cache: pip
 


### PR DESCRIPTION
It is now the default and does not need to be specified.