### PR TITLE
Fix extra space test case to avoid usage of unsupported tag

### DIFF
--- a/tests/data/extra-space.html
+++ b/tests/data/extra-space.html
@@ -1,1 +1,1 @@
-<p>one <span> two <u> three </u> </span> four</p>
+<p>one <em> two <u> three </u> </em> four</p>

--- a/tests/data/extra-space.json
+++ b/tests/data/extra-space.json
@@ -3,10 +3,15 @@
         "text": "one two three four",
         "runs": [
             {
-                "text": "one two "
+                "text": "one "
+            },
+            {
+                "text": "two ",
+                "italic": true
             },
             {
                 "text": "three ",
+                "italic": true,
                 "underline": true
             },
             {


### PR DESCRIPTION
Span is ignored in our code. The code is made to process any tag including `span`. However including a tag that is ignored as a feature in test code is not correct.