### PR TITLE
Improve test_html2docx robustness

### DIFF
--- a/tests/test_html2docx.py
+++ b/tests/test_html2docx.py
@@ -44,8 +44,8 @@ def test_html2docx(html_path, spec_path):
     for p, p_spec in zip(doc.paragraphs, spec):
         assert p.text == p_spec["text"]
         assert p.style.name == p_spec.get("style", "Normal")
-        if p_spec.get("alignment"):
-            assert int(p.alignment) == p_spec["alignment"]
+        if p_spec.get("alignment") is not None:
+            assert p.alignment == p_spec["alignment"]
         else:
             assert p.alignment is None
         if p_spec.get("left_indent"):


### PR DESCRIPTION
Don’t consider left alignment (value 0 in the enum) the same as no
alignment specified (None):

> A value of None indicates the paragraph has no directly-applied
  alignment value and will inherit its alignment value from its style
  hierarchy. Assigning None to this property removes any
  directly-applied alignment value.

https://python-docx.readthedocs.io/en/latest/api/text.html#docx.text.paragraph.Paragraph.alignment

Avoid unnecessary test post-processing. The alignment values are
declared as integers in the JSON, no casting is required.