### PR TITLE
Support align attributes on <p>

### DIFF
--- a/html2docx/html2docx.py
+++ b/html2docx/html2docx.py
@@ -84,6 +84,9 @@ class HTML2Docx(HTMLParser):
         self.collapse_space = True
 
     def init_p(self, attrs: List[Tuple[str, Optional[str]]]) -> None:
+        align = get_attr(attrs, "align")
+        if align:
+            self.alignment = ALIGNMENTS.get(align, WD_ALIGN_PARAGRAPH.LEFT)
         style = get_attr(attrs, "style")
         for style_decl in style_to_css(style):
             if style_decl["name"] == "text-align":
@@ -139,7 +142,11 @@ class HTML2Docx(HTMLParser):
 
         image_buffer = load_image(src)
         size = image_size(image_buffer, width_px, height_px)
-        self.doc.add_picture(image_buffer, **size)
+        paragraph = self.doc.add_paragraph()
+        if self.alignment is not None:
+            paragraph.alignment = self.alignment
+        run = paragraph.add_run()
+        run.add_picture(image_buffer, **size)
 
     def handle_starttag(self, tag: str, attrs: List[Tuple[str, Optional[str]]]) -> None:
         if tag == "a":

--- a/tests/data/align.html
+++ b/tests/data/align.html
@@ -1,3 +1,8 @@
 <p style="text-align: center;">Centered paragraph.</p>
 <p style="text-align: right;">This paragraph is aligned to the right.</p>
 <p style="text-align: justify;">This paragraph is justified.</p>
+<p align="left">Left alignment.</p>
+<p align="center">Centered alignment.</p>
+<p align="right">Right alignment.</p>
+<p align="justify">Justified alignment.</p>
+<p align="center" style="text-align: right;">Inline style has priority over align attribute.</p>

--- a/tests/data/align.json
+++ b/tests/data/align.json
@@ -25,5 +25,50 @@
                 "text": "This paragraph is justified."
             }
         ]
+    },
+    {
+        "text": "Left alignment.",
+        "alignment": 0,
+        "runs": [
+            {
+                "text": "Left alignment."
+            }
+        ]
+    },
+    {
+        "text": "Centered alignment.",
+        "alignment": 1,
+        "runs": [
+            {
+                "text": "Centered alignment."
+            }
+        ]
+    },
+    {
+        "text": "Right alignment.",
+        "alignment": 2,
+        "runs": [
+            {
+                "text": "Right alignment."
+            }
+        ]
+    },
+    {
+        "text": "Justified alignment.",
+        "alignment": 3,
+        "runs": [
+            {
+                "text": "Justified alignment."
+            }
+        ]
+    },
+    {
+        "text": "Inline style has priority over align attribute.",
+        "alignment": 2,
+        "runs": [
+            {
+                "text": "Inline style has priority over align attribute."
+            }
+        ]
     }
 ]

--- a/tests/data/img_alignment.html
+++ b/tests/data/img_alignment.html
@@ -1,0 +1,3 @@
+<p align="center">
+<img src="https://via.placeholder.com/1x1.png">
+</p>

--- a/tests/data/img_alignment.json
+++ b/tests/data/img_alignment.json
@@ -1,0 +1,18 @@
+[
+    {
+        "text": "",
+        "alignment": 1,
+        "runs": [
+            {
+                "text": "",
+                "shapes": [
+                    {
+                        "type": 3,
+                        "width": 9525,
+                        "height": 9525
+                    }
+                ]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
The [legacyoutput plugin](https://www.tiny.cloud/docs/plugins/legacyoutput/) of TinyMCE sets alignment through the `align` attribute, instead of using the `text-align` property.