### PR TITLE
Use default resolution when scaling image size

### DIFF
--- a/tests/data/img_height.json
+++ b/tests/data/img_height.json
@@ -7,8 +7,8 @@
                 "shapes": [
                     {
                         "type": 3,
-                        "width": 2857500,
-                        "height": 2857500
+                        "width": 3810000,
+                        "height": 3810000
                     }
                 ]
             }

--- a/tests/data/img_ratio.json
+++ b/tests/data/img_ratio.json
@@ -7,8 +7,8 @@
                 "shapes": [
                     {
                         "type": 3,
-                        "width": 190500,
-                        "height": 95250
+                        "width": 254000,
+                        "height": 127000
                     }
                 ]
             }

--- a/tests/data/img_width.json
+++ b/tests/data/img_width.json
@@ -7,8 +7,8 @@
                 "shapes": [
                     {
                         "type": 3,
-                        "width": 2857500,
-                        "height": 2857500
+                        "width": 3810000,
+                        "height": 3810000
                     }
                 ]
             }

--- a/tests/test_image_size.py
+++ b/tests/test_image_size.py
@@ -2,19 +2,19 @@ from math import ceil
 
 from docx.shared import Inches
 
-from html2docx.image import USABLE_HEIGHT, USABLE_WIDTH, image_size
+from html2docx.image import DEFAULT_DPI, USABLE_HEIGHT, USABLE_WIDTH, image_size
 
-from .utils import DPI, PROJECT_DIR, generate_image
+from .utils import PROJECT_DIR, generate_image
 
 broken_image = PROJECT_DIR / "html2docx" / "image-broken.png"
 broken_image_bytes = broken_image.read_bytes()
 
 
-def inches_to_px(inches: int, dpi: int = DPI) -> int:
+def inches_to_px(inches: int, dpi: int = DEFAULT_DPI) -> int:
     return ceil(inches / Inches(1) * dpi)
 
 
-def px_to_inches(px: int, dpi: int = DPI) -> int:
+def px_to_inches(px: int, dpi: int = DEFAULT_DPI) -> int:
     return ceil(px * Inches(1) / dpi)
 
 
@@ -77,15 +77,29 @@ def test_resize_exceeds_height():
     assert size == {"height": USABLE_HEIGHT}
 
 
-def test_dpi_width():
+def test_no_pixel_size_uses_dpi_width():
     width_px = inches_to_px(USABLE_WIDTH, 300)
     image = generate_image(width=width_px, height=1, dpi=(300, 300))
     size = image_size(image)
     assert size == {}
 
 
-def test_dpi_height():
+def test_no_pixel_size_uses_dpi_height():
     height_px = inches_to_px(USABLE_HEIGHT, 300)
     image = generate_image(width=1, height=height_px, dpi=(300, 300))
     size = image_size(image)
     assert size == {}
+
+
+def test_pixel_size_specified_ignores_dpi_width():
+    width_px = inches_to_px(Inches(1))
+    image = generate_image(width=width_px, height=1, dpi=(300, 300))
+    size = image_size(image, width_px=width_px)
+    assert size == {"width": Inches(1)}
+
+
+def test_pixel_size_specified_ignores_dpi_height():
+    height_px = inches_to_px(Inches(1))
+    image = generate_image(width=1, height=height_px, dpi=(300, 300))
+    size = image_size(image, height_px=height_px)
+    assert size == {"height": Inches(1)}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,12 +3,13 @@ from io import BytesIO
 
 from PIL import Image
 
+from html2docx.image import DEFAULT_DPI
+
 TEST_DIR = pathlib.Path(__file__).parent.resolve(strict=True)
 PROJECT_DIR = TEST_DIR.parent
-DPI = 72
 
 
-def generate_image(width: int, height: int, dpi=(DPI, DPI)) -> BytesIO:
+def generate_image(width: int, height: int, dpi=(DEFAULT_DPI, DEFAULT_DPI)) -> BytesIO:
     data = BytesIO()
     with Image.new("L", (width, height)) as image:
         image.save(data, format="png", dpi=dpi)


### PR DESCRIPTION
Scaling the images based on their resolution is good when the image size is unconstrained, it prevents images with a high resolution from appearing larger than images with a lower resolution but the same pixel size.

When the image size is constrained, ignore resolution and scale image to the constrained size.

The default DPI is now used in the project, moved the constant from the tests to html2docx/image.py and renamed it to `DEFAULT_DPI` to better describe it.