### PR TITLE
Upgrade to isort 5

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,8 +24,8 @@ deps = flake8
 skip_install = true
 
 [testenv:isort]
-commands = isort --recursive --check-only --diff
-deps = isort
+commands = isort --check-only --diff .
+deps = isort >= 5.0.0
 skip_install = true
 
 [testenv:mypy]


### PR DESCRIPTION
https://timothycrosley.github.io/isort/docs/major_releases/introducing_isort_5/

The --recursive flag is now the default behavior and has been
deprecated.