### PR TITLE
Handle <p> in <li>

### DIFF
--- a/tests/data/list_li_contains_p.html
+++ b/tests/data/list_li_contains_p.html
@@ -1,0 +1,6 @@
+<ul>
+    <li>
+        <p>Lou King:</p>
+        <p>Actions: bifurcate, twist, turn.</p>
+    </li>
+</ul>

--- a/tests/data/list_li_contains_p.json
+++ b/tests/data/list_li_contains_p.json
@@ -1,0 +1,11 @@
+[
+    {
+        "text": "Lou King:\nActions: bifurcate, twist, turn.",
+        "style": "List Bullet",
+        "runs": [
+            {
+                "text": "Lou King:\nActions: bifurcate, twist, turn."
+            }
+        ]
+    }
+]

--- a/tests/data/list_li_contains_p_with_style.html
+++ b/tests/data/list_li_contains_p_with_style.html
@@ -1,0 +1,6 @@
+<ul>
+    <li>
+        <p><strong>Lou King:</strong></p>
+        <p>Actions: bifurcate, twist, turn.</p>
+    </li>
+</ul>

--- a/tests/data/list_li_contains_p_with_style.json
+++ b/tests/data/list_li_contains_p_with_style.json
@@ -1,0 +1,15 @@
+[
+    {
+        "text": "Lou King:\nActions: bifurcate, twist, turn.",
+        "style": "List Bullet",
+        "runs": [
+            {
+                "text": "Lou King:",
+                "bold": true
+            },
+            {
+                "text": "\nActions: bifurcate, twist, turn."
+            }
+        ]
+    }
+]


### PR DESCRIPTION
A docx document represents li as paragraphs with style “List Bullet” or
“List Number”. A paragraph cannot contain other paragraphs. When a `<p>`
is nested under an `<li>`, do not open a paragraph in the docx document.
Instead, add a line break to separate the `<p>` visually.