### PR TITLE
Do not pass attrs to <p> runs inside <li>

### DIFF
--- a/html2docx/html2docx.py
+++ b/html2docx/html2docx.py
@@ -178,7 +178,7 @@ class HTML2Docx(HTMLParser):
             if self.list_style:
                 if self.p and self.p.runs:
                     self.add_text("\n")
-                self.init_run(attrs)
+                self.init_run([])
             else:
                 self.init_p(attrs)
         elif tag == "pre":

--- a/tests/data/list_li_p_with_attrs.html
+++ b/tests/data/list_li_p_with_attrs.html
@@ -1,0 +1,5 @@
+<ul>
+    <li>
+        <p class="author">Lou King</p>
+    </li>
+</ul>

--- a/tests/data/list_li_p_with_attrs.json
+++ b/tests/data/list_li_p_with_attrs.json
@@ -1,0 +1,11 @@
+[
+    {
+        "text": "Lou King",
+        "style": "List Bullet",
+        "runs": [
+            {
+                "text": "Lou King"
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Reading the style attribute is currently unsupported. Other attributes
should be ignored.

Fixes #63 