### PR TITLE
Use PEP518 pyproject.toml to create dist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+]
+build-backend = "setuptools.build_meta:__legacy__"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     flake8
     isort
     mypy
+isolated_build = True
 minversion = 1.9
 
 [testenv]


### PR DESCRIPTION
Setup.py is basically deprecated.
https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html

Configure tox to use PEP 517 and PEP 518 builds. From
https://tox.wiki/en/latest/example/package.html:

> To create a source distribution there are multiple tools out there and
  with PEP-517 and PEP-518 you can easily use your favorite one with
  tox. Historically tox only supported setuptools, and always used the
  tox host environment to build a source distribution from the source
  tree. This is still the default behavior. To opt out of this behaviour
  you need to set isolated builds to true.