### PR TITLE
Simplify pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,3 @@
 [build-system]
-requires = [
-    "setuptools>=42",
-    "wheel",
-]
-build-backend = "setuptools.build_meta:__legacy__"
+requires = ["setuptools>=42"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
https://code.djangoproject.com/ticket/33778

The wheel dependency is redundant and discouraged here. Setuptools adds
this dependency via the backend automatically since day one. It was
historically included in the documentation but it was a mistake. See:
https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a

The legacy backend was never supposed to be used in pyproject.toml. It
is only an "internal" fallback that is used by tools like pip when
pyproject.toml is not present at all. The regular backend must always be
used in pyproject.toml. See:
https://github.com/pypa/setuptools/issues/1689