### PR TITLE
Account for `pre` when adding text

### DIFF
--- a/html2docx/html2docx.py
+++ b/html2docx/html2docx.py
@@ -99,7 +99,7 @@ class HTML2Docx(HTMLParser):
                 self.padding_left = Pt(style_decl["value"])
 
     def finish_p(self) -> None:
-        if self.r is not None:
+        if not self.pre and self.r is not None:
             self.r.text = self.r.text.rstrip()
         self._reset()
 
@@ -161,7 +161,10 @@ class HTML2Docx(HTMLParser):
             for attrs in self.attrs:
                 for font_attr, value in attrs:
                     setattr(self.r.font, font_attr, value)
-        self.r.add_text(data)
+        if self.pre:
+            self.r.text = data
+        else:
+            self.r.add_text(data)
 
     def add_list_style(self, name: str) -> None:
         self.finish_p()

--- a/tests/data/pre-nested-strong.html
+++ b/tests/data/pre-nested-strong.html
@@ -1,0 +1,2 @@
+<pre>line1
+<strong>line2</strong></pre>

--- a/tests/data/pre-nested-strong.json
+++ b/tests/data/pre-nested-strong.json
@@ -1,0 +1,14 @@
+[
+    {
+        "text": "line1\nline2",
+        "runs": [
+            {
+                "text": "line1\n"
+            },
+            {
+                "text": "line2",
+                "bold": true
+            }
+        ]
+    }
+]


### PR DESCRIPTION
run.add_text and assigning to run.text have different outcomes. The latter translates the incoming text to insert docx elements such as tabs and line breaks.

ref: https://python-docx.readthedocs.io/en/latest/api/text.html#docx.text.run.Run.text